### PR TITLE
Fix scp rename issue on MINGW64 distribution

### DIFF
--- a/src/report.js
+++ b/src/report.js
@@ -125,7 +125,7 @@ async function report(results) {
     let file = path.join(util.resultsDir, `${util.timestamp.substring(0, 8)}.json`);
     await fs.writeFileSync(file, JSON.stringify(results['performance']));
     if ('upload' in util.args) {
-      let result = spawnSync('scp', [file, `wp@wp-27.sh.intel.com:/workspace/project/work/tfjs/data/${util['gpuDeviceId']}/`]);
+      let result = spawnSync('scp', [file, `wp@wp-27.sh.intel.com:/workspace/project/work/tfjs/data/${util['gpuDeviceId']}/${util.timestamp.substring(0, 8)}.json`]);
       if (result.status !== 0) {
         console.log('[ERROR] Failed to upload report');
       } else {


### PR DESCRIPTION
On MinGW64, commend `"scp 'C:\1.txt' xx@xx:\xx\"` will translate `'C:\1.txt'` not `'1.txt'` to
remote machine, add destination file name to the end to fix this problem