### PR TITLE
Add tfjs-core to localBuild

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -41,7 +41,7 @@ module.exports = {
   'targetMetrics': targetMetrics,
   'outDir': outDir,
   'url': 'http://wp-27.sh.intel.com/workspace/project/tfjswebgpu/tfjs/e2e/benchmarks/local-benchmark/',
-  'urlArgs': 'localBuild=webgl,webgpu&WEBGL_USE_SHAPES_UNIFORMS=true',
+  'urlArgs': 'localBuild=core,webgl,webgpu&WEBGL_USE_SHAPES_UNIFORMS=true',
   'timeout': 180 * 1000,
   log: log,
 };


### PR DESCRIPTION
Due to https://github.com/tensorflow/tfjs/pull/5789, tfjs-core exported
broadcast util to other backends. We should keep tfjs-core align with other
backends