### PR TITLE
Add tracing parser tool

### DIFF
--- a/src/tracingJsonParser.js
+++ b/src/tracingJsonParser.js
@@ -1,0 +1,113 @@
+'use strict';
+const fs = require('fs');
+const url = require('url');
+
+/*
+ trace format:
+ {"args":{},"cat":"disabled-by-default-gpu.dawn","dur":42942,"name":"DeviceBase::APICreateComputePipeline","ph":"X","pid":3276,"tdur":42778,"tid":24624,"ts":1183083225222,"tts":440215},
+ ts: timestamp, at microsecond.
+ tdur: wall duration, at microsecond.
+*/
+
+// The API names.
+const traceKey = 'name';
+
+// Trace values.
+const traceValue = 'dur';
+const traceTimestamp = 'ts';
+const traceLabel = 'label';
+
+function TraceRecord(label, duration, timestamp) {
+  this.label = label;
+  this.duration = duration;
+  this.timestamp = timestamp;
+}
+
+// Parse a single model from a json file.
+function parseSingleModel(jsonFile, apiNames) {
+  let rawdata = fs.readFileSync(jsonFile);
+  let parsedData = JSON.parse(rawdata);
+  const resultData = {};
+  for (const x in parsedData) {
+    if (x === 'traceEvents') {
+      const traces = parsedData[x];
+      for (const y in traces) {
+        apiNames.forEach(function(api) {
+          if (traces[y][traceKey] === api) {
+            if (!resultData[api]) {
+              resultData[api] = new Array();
+            }
+            resultData[api].push(new TraceRecord(
+                traces[y].args[traceLabel],
+                (traces[y][traceValue] / 1000).toFixed(3),
+                (traces[y][traceTimestamp] / 1000).toFixed(3)));
+          }
+        });
+      }
+    }
+  }
+  return resultData;
+}
+
+// Multiple model only. Used to get model boundary.
+function isModel(trace, modelUrlTag) {
+  const modelNameTag = 'NavigationControllerImpl::LoadURLWithParams';
+  if (trace[traceKey] == modelNameTag) {
+    if ((trace['args']['url']).includes(modelUrlTag)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Multiple model only. Used to get model info.
+function getModelInfo(trace) {
+  const url = new URL(trace['args']['url']);
+  const modelKeys = [
+    'task', 'backend', 'benchmark', 'architecture', 'inputType', 'inputSize'
+  ];
+  var modelInfo = '';
+  modelKeys.forEach(function(key, index) {
+    if (url.searchParams.has(key)) {
+      const prefix = modelInfo === '' ? '' : ' ';
+      modelInfo += prefix + url.searchParams.get(key);
+    }
+  });
+  return modelInfo;
+}
+
+// Parse multiple models from a json file.
+function parseMultipleModels(jsonFile, apiNames, modelUrlTag) {
+  let rawdata = fs.readFileSync(jsonFile);
+  let parsedData = JSON.parse(rawdata);
+  const resultData = {};
+  for (const x in parsedData) {
+    if (x === 'traceEvents') {
+      const traces = parsedData[x];
+      var modelName;
+      for (const y in traces) {
+        apiNames.forEach(function(api) {
+          if (isModel(traces[y], modelUrlTag)) {
+            modelName = getModelInfo(traces[y]);
+            resultData[modelName] = {};
+          }
+          if (traces[y][traceKey] === api) {
+            if (!resultData[modelName][api]) {
+              resultData[modelName][api] = new Array();
+            }
+            resultData[modelName][api].push(new TraceRecord(
+                traces[y].args[traceLabel],
+                (traces[y][traceValue] / 1000).toFixed(3),
+                (traces[y][traceTimestamp] / 1000).toFixed(3)));
+          }
+        });
+      }
+    }
+  }
+  return resultData;
+}
+
+module.exports = {
+  parseSingleModel: parseSingleModel,
+  parseMultipleModels: parseMultipleModels,
+};

--- a/src/tracingdemo.js
+++ b/src/tracingdemo.js
@@ -1,0 +1,124 @@
+'use strict';
+const yargs = require('yargs');
+const fs = require('fs');
+const tracingJsonParser = require('./tracingJsonParser');
+
+/* Steps:
+1. generate tracing json file
+Generate by webtest:
+node webtest\src\main.js  --warmup-times 1
+ --run-times 0 --trace disabled-by-default-gpu.dawn,navigation --target
+performance
+ --performance-backend webgpu --url http://www.abc.com --disable-breakdown
+
+Or by chromium:
+chrome.exe --enable-tracing=disabled-by-default-gpu.dawn,navigation
+--trace-startup-file=abc.json
+
+2. node tracingdemo.js
+*/
+
+const args =
+    yargs.usage('node $0 [args]')
+        .strict()
+        .option('files', {
+          type: 'string',
+          describe: 'JSON files to be parsed',
+        })
+        .option('url', {
+          type: 'string',
+          describe: 'Url is used to get model name',
+        })
+        .option('apis', {
+          type: 'string',
+          describe: 'List all used APIs, split by comma',
+          default:
+              'DeviceBase::APICreateShaderModule,DeviceBase::APICreateComputePipeline,DeviceBase::APICreateComputePipelineAsync',
+        })
+        .example([
+          [
+            'node $0 --apis=DeviceBase::APICreateShaderModule,DeviceBase::APICreateComputePipeline',
+            '# Test Dawn APIs'
+          ],
+        ])
+        .help()
+        .wrap(120)
+        .argv;
+
+function getApiNames() {
+  let apiNames = args['apis'].split(',');
+  return apiNames;
+}
+
+function getFiles() {
+  let files = [];
+  if ('files' in args) {
+    files = args['files'].split(',');
+  } else {
+    files = getAllJsonFiles();
+  }
+  return files;
+}
+
+function getOutputFile() {
+  var file = '';
+  if ('o' in args) {
+    file = args['o'];
+  } else {
+    file = 'Tracing-API-Summary.xlsx';
+  }
+  return file;
+}
+
+function getUrl() {
+  var modelUrlTag = '';
+  if ('url' in args) {
+    modelUrlTag = args['url'];
+  } else {
+    modelUrlTag = 'tfjs/e2e/benchmarks/local-benchmark';
+  }
+  return modelUrlTag;
+}
+
+function isJsonFile(fileName) {
+  var splitFileName = fileName.split('.');
+  if (splitFileName[splitFileName.length - 1] == 'json') {
+    return true;
+  }
+  return false;
+}
+
+function getAllJsonFiles() {
+  const jsonFolder = './';
+  const files = new Array();
+
+  fs.readdirSync(jsonFolder).forEach(fileName => {
+    if (isJsonFile(fileName)) {
+      files.push(fileName);
+    }
+  });
+  return files;
+}
+
+function main() {
+  const modelUrlTag = getUrl();
+  const apiNames = getApiNames();
+  const allFiles = getFiles();
+
+  // Case 1: parse single model.
+  for (const file in allFiles) {
+    const jsonData =
+        tracingJsonParser.parseSingleModel(allFiles[file], apiNames);
+    console.log(JSON.stringify(jsonData));
+  }
+
+  // Case 2: parse multiple models.
+  for (const file in allFiles) {
+    const jsonData = tracingJsonParser.parseMultipleModels(
+        allFiles[file], apiNames, modelUrlTag);
+    console.log(JSON.stringify(jsonData));
+  }
+}
+
+
+main();


### PR DESCRIPTION
Steps:
1. generate tracing json file
Generate by webtest:
node webtest\src\main.js  --warmup-times 1
 --run-times 0 --trace disabled-by-default-gpu.dawn,navigation --target
performance
 --performance-backend webgpu --url http://www.abc.com --disable-breakdown

Or by chromium:
chrome.exe --enable-tracing=disabled-by-default-gpu.dawn,navigation
--trace-startup-file=abc.json

2. node tracingdemo.js