### PR TITLE
Enable CPU GPU timeline

### DIFF
--- a/src/benchmark.js
+++ b/src/benchmark.js
@@ -158,7 +158,7 @@ async function runBenchmark(target, modelSummaryDir, benchmarkJsonFile = 'benchm
     util.log(`[${i + 1}/${benchmarksLength}] ${benchmark}`);
 
     if ('new-context' in util.args) {
-      if ('trace-category' in util.args) {
+      if (util.getTraceFlag()) {
         traceFile = `${modelSummaryDir}/${benchmark.join('-').replace(/ /g, '_')}-trace.json`;
         if (util.gpufreqTraceFile === '') {
           util.gpufreqTraceFile = traceFile;

--- a/src/benchmark.js
+++ b/src/benchmark.js
@@ -30,8 +30,12 @@ function intersect(a, b) {
 
 async function startContext(traceFile = '') {
   let traceArgs = '';
-  if ('trace-category' in util.args) {
-    traceArgs = `--enable-tracing=${util.args['trace-category']} --trace-startup-file=${traceFile}`;
+  if (util.args['tracing'] === 'all' || util.gpufreqTraceFile === '') {
+    traceArgs = ` --enable-dawn-features=record_detailed_timing_in_trace_events,disable_timestamp_query_conversion
+      --trace-startup-format=json --enable-tracing=${util.args['trace-category']} --trace-startup-file=${traceFile}`;
+  } else  if (util.args['tracing'] === 'gpu') {
+    traceArgs = ` --enable-dawn-features=record_detailed_timing_in_trace_events,disable_timestamp_query_conversion
+      --trace-startup-file=${traceFile}`;
   }
 
   if (!util.dryrun) {
@@ -64,14 +68,14 @@ async function closeContext(context) {
   }
 }
 
-async function runBenchmark(target) {
+async function runBenchmark(target, modelSummaryDir, benchmarkJsonFile = 'benchmark.json') {
   // get benchmarks
   let benchmarks = [];
-  let benchmarkJson = path.join(path.resolve(__dirname), 'benchmark.json');
+  let benchmarkJson = path.join(path.resolve(__dirname), benchmarkJsonFile);
   let targetConfigs = JSON.parse(fs.readFileSync(benchmarkJson));
 
   for (let config of targetConfigs) {
-    if ('benchmark' in util.args) {
+    if ('benchmark' in util.args && util.args['benchmark']) {
       config['benchmark'] = intersect(config['benchmark'], util.args['benchmark'].split(','));
     }
     if (!config['benchmark']) {
@@ -158,7 +162,10 @@ async function runBenchmark(target) {
 
     if ('new-context' in util.args) {
       if ('trace-category' in util.args) {
-        traceFile = `${util.outDir}/${util.timestamp}-trace-${benchmark.join('-').replace(/ /g, '_')}.json`;
+        traceFile = `${modelSummaryDir}/${benchmark.join('-').replace(/ /g, '_')}-trace.json`;
+        if (util.gpufreqTraceFile === '') {
+          util.gpufreqTraceFile = traceFile;
+        }
       }
       [context, page] = await startContext(traceFile);
     }
@@ -280,9 +287,6 @@ async function runBenchmark(target) {
 
     if ('new-context' in util.args) {
       await closeContext(context);
-    }
-    if ('trace-category' in util.args) {
-      await parseTrace(traceFile, totalTime);
     }
   }
 

--- a/src/benchmark.js
+++ b/src/benchmark.js
@@ -30,12 +30,9 @@ function intersect(a, b) {
 
 async function startContext(traceFile = '') {
   let traceArgs = '';
-  if (util.args['tracing'] === 'all' || util.gpufreqTraceFile === '') {
+  if (util.getTraceFlag()) {
     traceArgs = ` --enable-dawn-features=record_detailed_timing_in_trace_events,disable_timestamp_query_conversion
       --trace-startup-format=json --enable-tracing=${util.args['trace-category']} --trace-startup-file=${traceFile}`;
-  } else  if (util.args['tracing'] === 'gpu') {
-    traceArgs = ` --enable-dawn-features=record_detailed_timing_in_trace_events,disable_timestamp_query_conversion
-      --trace-startup-file=${traceFile}`;
   }
 
   if (!util.dryrun) {

--- a/src/benchmark_getinfo.json
+++ b/src/benchmark_getinfo.json
@@ -1,0 +1,6 @@
+[
+  {
+    "benchmark": "mobilenet_v2",
+    "backend": ["webgpu"]
+  }
+]

--- a/src/benchmark_getinfo.json
+++ b/src/benchmark_getinfo.json
@@ -1,6 +1,0 @@
-[
-  {
-    "benchmark": "mobilenet_v2",
-    "backend": ["webgpu"]
-  }
-]

--- a/src/main.js
+++ b/src/main.js
@@ -293,7 +293,7 @@ async function main() {
 
   util.benchmarkUrlArgs += `&warmup=${warmupTimes}&run=${runTimes}&profile=${profileTimes}&localBuild=${util.args['local-build']}`;
 
-  if ('trace-category' in util.args) {
+  if (util.getTraceFlag()) {
     util.args['new-context'] = true;
     util.benchmarkUrlArgs +=`&tracing=true`;
   }
@@ -324,9 +324,8 @@ async function main() {
 
   const trace = 'trace' in util.args || 'trace-category' in util.args;
   if (trace == true) {
-    console.log("Tracing is ON: "+ util.args['trace']);
     if (util.args['trace-category'] == null) {
-      throw new Error("Tracing all mode, but trace-category is not defined");
+      util.args['trace-category'] = 'disabled-by-default-gpu.dawn';
     }
     util.benchmarkUrlArgs +=`&tracing=${trace}`;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -327,6 +327,7 @@ async function main() {
     if (util.args['trace-category'] == null) {
       util.args['trace-category'] = 'disabled-by-default-gpu.dawn';
     }
+    util.args['disable-breakdown'] = true;
     util.benchmarkUrlArgs +=`&tracing=${trace}`;
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -329,9 +329,6 @@ async function main() {
       throw new Error("Tracing all mode, but trace-category is not defined");
     }
     util.benchmarkUrlArgs +=`&tracing=${tracing}`;
-    util.timestamp = getTimestamp(util.args['timestamp']);
-    util.logFile = path.join(util.outDir, `${util.timestamp}-gpufreq.log`);
-    await getGPUFreq(util.outDir);
   }
 
   let results = {};
@@ -385,16 +382,6 @@ function createSummaryFolder(logfileName) {
     console.error(err)
   }
   return modelSummaryDir;
-}
-
-async function getGPUFreq(modelSummaryDir) {
-  const target = 'performance';
-  const benchmarkFileForGpufreq = 'benchmark_getinfo.json';
-  util.log(`=Get GPU Frequency=` + util.args['benchmark']);
-  const lastArgs = util.args['benchmark'];
-  util.args['benchmark'] = null;
-  await runBenchmark(target, modelSummaryDir, benchmarkFileForGpufreq);
-  util.args['benchmark'] = lastArgs;
 }
 
 main();

--- a/src/main.js
+++ b/src/main.js
@@ -293,11 +293,6 @@ async function main() {
 
   util.benchmarkUrlArgs += `&warmup=${warmupTimes}&run=${runTimes}&profile=${profileTimes}&localBuild=${util.args['local-build']}`;
 
-  if (util.getTraceFlag()) {
-    util.args['new-context'] = true;
-    util.benchmarkUrlArgs +=`&tracing=true`;
-  }
-
   if ('benchmark-url-args' in util.args) {
     util.benchmarkUrlArgs += `&${util.args['benchmark-url-args']}`;
   }
@@ -322,8 +317,9 @@ async function main() {
     await config();
   }
 
-  const trace = 'trace' in util.args || 'trace-category' in util.args;
+  const trace = util.getTraceFlag();
   if (trace == true) {
+    util.args['new-context'] = true;
     if (util.args['trace-category'] == null) {
       util.args['trace-category'] = 'disabled-by-default-gpu.dawn';
     }

--- a/src/main.js
+++ b/src/main.js
@@ -144,9 +144,9 @@ util.args = yargs
     type: 'string',
     describe: 'trace file',
   })
-  .option('tracing', {
+  .option('trace', {
     type: 'string',
-    describe: 'Enable tracing: all, gpu',
+    describe: 'Enable tracing',
   })
   .option('unit-backend', {
     type: 'string',
@@ -322,13 +322,13 @@ async function main() {
     await config();
   }
 
-  const tracing = 'tracing' in util.args || 'trace-category' in util.args;
-  if (tracing == true) {
-    console.log("Tracing is ON: "+ util.args['tracing']);
-    if (util.args['tracing'] === 'all' && util.args['trace-category'] == null) {
+  const trace = 'trace' in util.args || 'trace-category' in util.args;
+  if (trace == true) {
+    console.log("Tracing is ON: "+ util.args['trace']);
+    if (util.args['trace-category'] == null) {
       throw new Error("Tracing all mode, but trace-category is not defined");
     }
-    util.benchmarkUrlArgs +=`&tracing=${tracing}`;
+    util.benchmarkUrlArgs +=`&tracing=${trace}`;
   }
 
   let results = {};
@@ -341,7 +341,7 @@ async function main() {
       fs.truncateSync(util.logFile, 0);
     }
 
-    const modelSummaryDir = tracing ? createSummaryFolder(util.logFile) : '';
+    const modelSummaryDir = trace ? createSummaryFolder(util.logFile) : '';
 
     if (util.args['repeat'] > 1) {
       util.log(`== Test round ${i + 1}/${util.args['repeat']} ==`);
@@ -365,8 +365,8 @@ async function main() {
       util.duration += `${target}: ${(new Date() - startTime) / 1000} `;
     }
 
-    if (tracing == true) {
-      await modelSummary(modelSummaryDir, util.logFile, results, util.benchmarkUrlArgs, util.gpufreqTraceFile, util.args['tracing']);
+    if (trace == true) {
+      await modelSummary(modelSummaryDir, util.logFile, results, util.benchmarkUrlArgs, util.gpufreqTraceFile, 'all');
     }
     await report(results);
   }

--- a/src/trace.js
+++ b/src/trace.js
@@ -11,6 +11,7 @@ const {
   getModelNames,
   getModelNamesFromLog,
   getAverageInfoFromLog,
+  splitTracingByModel,
 } = require('./trace_util.js');
 const fs = require('fs');
 const fsasync = require('fs').promises;
@@ -83,6 +84,8 @@ async function modelSummary(
         tracingPredictTimes, gpuJsonDataForModel, modelNames[i], linkInfo,
         gpuFreq, tracingMode);
 
+    await splitTracingByModel(
+        `${modelNames[i]}-webgpu-trace.json`, [modelNames[i]], modelSummarDir);
     for (var j = 0; j < repeat; j++) {
       const name = modelName + '-' + (j + 1);
       fs.writeFileSync(

--- a/src/trace.js
+++ b/src/trace.js
@@ -1,34 +1,105 @@
-'use strict';
-
+const {createModelFromData, getBaseTimeFromTracing} =
+    require('./trace_model.js');
+const {
+  createTableStartWithLink,
+  createTableStartWithInfo,
+  createTableEnd,
+  createTableRows
+} = require('./trace_ui.js');
+const {
+  getJsonFromString,
+  getModelNames,
+  getModelNamesFromLog,
+  getAverageInfoFromLog,
+} = require('./trace_util.js');
 const fs = require('fs');
-const path = require('path');
-const util = require('./util.js');
+const fsasync = require('fs').promises;
 
-function parseTrace(traceFile = '', totalTime = 0) {
-  let eventNames = ['DeviceBase::APICreateComputePipeline', 'CreateComputePipelineAsyncTask::Run', 'DeviceBase::APICreateShaderModule'];
-  let results = {};
-  let base_ts = 0;
+function updateUI(tableName, mergedData, modelName, linkInfo, tracingMode) {
+  // Update UI.
+  let modelTable = createTableStartWithInfo(tableName);
 
-  if (!traceFile) {
-    traceFile = `${util.outDir}/${util.args['trace-file']}.json`;
-  }
-  let jsonData = JSON.parse(fs.readFileSync(traceFile));
-  for (let event of jsonData['traceEvents']) {
-    let eventName = event['name']
-    if (eventNames.indexOf(eventName) >= 0) {
-      if (base_ts == 0) {
-        base_ts = event['ts'];
-      }
-      if (!(eventName in results)) {
-        results[eventName] = [];
-      }
-      results[eventName].push([(event['ts'] - base_ts) / 1000, event['dur'] / 1000]);
-    }
-  }
-  results['total'] = [[0, totalTime]];
-  console.log(results);
-  let timelineFile = traceFile.replace('-trace', '');
-  fs.writeFileSync(timelineFile, JSON.stringify(results));
+  modelTable += createTableEnd();
+
+  let table = '';
+  let headdata = Object.keys(mergedData[0]);
+  table += createTableStartWithLink(headdata, modelName, linkInfo, tracingMode);
+  table += createTableRows(mergedData);
+  table += createTableEnd();
+  return modelTable + table;
 }
 
-module.exports = parseTrace;
+async function singleModelSummary(
+    tabelName, tracingPredictTime, tracingGpuData, modelName, linkInfo, gpuFreq,
+    tracingMode, profilePredictJsonData = null, profileJsonData = null) {
+  const mergedData = await createModelFromData(
+      tracingPredictTime, tracingGpuData, gpuFreq, true, profilePredictJsonData,
+      profileJsonData);
+  return updateUI(tabelName, mergedData, modelName, linkInfo, tracingMode);
+}
+
+async function modelSummary(
+    modelSummarDir, logfileName, results, benchmarkUrlArgs, gpuFreqTracingFile,
+    tracingMode) {
+  if (logfileName == null) {
+    console.error('No log file!');
+  }
+  console.log('logfileName = ' + logfileName);
+  const logStr = await fsasync.readFile(logfileName, 'binary');
+  const modelNames =
+      results == null ? getModelNamesFromLog(logStr) : getModelNames(results);
+
+  const averageInfos = getAverageInfoFromLog(logStr);
+  const predictJsonData =
+      getJsonFromString(logStr, 'predictbegin', 'predictend');
+  const gpuJsonData = getJsonFromString(logStr, 'gpudatabegin', 'gpudataend');
+
+  const [, , gpuFreq] = gpuFreqTracingFile ?
+      await getBaseTimeFromTracing(gpuFreqTracingFile) :
+      [0, 0, 19200000];
+  console.log('GPU Frequency: ' + gpuFreq);
+
+  let html = `<div>${benchmarkUrlArgs}</div>`;
+  const splitLogfileName = logfileName.split('\\');
+  const date = splitLogfileName[splitLogfileName.length - 1].split('.')[0];
+  const linkInfo = {
+    date: date,
+    gpufreq: gpuFreq,
+    benchmarkUrlArgs: benchmarkUrlArgs
+  };
+
+  // predictJsonData.length is the model number.
+  const modelCount = predictJsonData.length;
+  for (var i = 0; i < modelCount; i++) {
+    // Tracing may possible be repeated. predictJsonData[0]['times'].length
+    // is the repeat count.
+    const repeat = predictJsonData[0]['times'].length;
+    const modelName = modelSummarDir + '\\' + modelNames[i];
+    const tracingPredictTimes = predictJsonData[i]['times'];
+    const gpuJsonDataForModel = gpuJsonData.slice(i * repeat, (i + 1) * repeat);
+    html += await singleModelSummary(
+        modelNames[i].split('-')[0] + '-' +
+            averageInfos[i].replace('[object Object]', ''),
+        tracingPredictTimes, gpuJsonDataForModel, modelNames[i], linkInfo,
+        gpuFreq, tracingMode);
+
+    for (var j = 0; j < repeat; j++) {
+      const name = modelName + '-' + (j + 1);
+      fs.writeFileSync(
+          name + '.json', JSON.stringify(gpuJsonData[i * repeat + j]));
+    }
+
+    fs.writeFileSync(
+        modelName + '-predict.json', JSON.stringify(predictJsonData[i]));
+  }
+
+  const isRawTimestamp = true;
+  const modelSummaryFile = modelSummarDir + '\\' + date + '-raw' +
+      isRawTimestamp + '-modelsummary.html';
+  console.log(modelSummaryFile);
+  fs.writeFileSync(modelSummaryFile, html);
+}
+
+module.exports = {
+  modelSummary: modelSummary
+};

--- a/src/trace.js
+++ b/src/trace.js
@@ -11,7 +11,7 @@ const {
   getModelNames,
   getModelNamesFromLog,
   getAverageInfoFromLog,
-  splitTracingByModel,
+  splitTraceByModel,
 } = require('./trace_util.js');
 const fs = require('fs');
 const fsasync = require('fs').promises;
@@ -84,7 +84,7 @@ async function modelSummary(
         tracingPredictTimes, gpuJsonDataForModel, modelNames[i], linkInfo,
         gpuFreq, tracingMode);
 
-    const [tracingForModel, traceEnd] = await splitTracingByModel(
+    const [tracingForModel, traceEnd] = await splitTraceByModel(
         `${modelNames[i]}-webgpu-trace.json`, modelSummarDir);
     if (tracingForModel.length != repeat) {
       throw new Error(`${modelNames[i]} length of tracing for model(${

--- a/src/trace_model.js
+++ b/src/trace_model.js
@@ -1,0 +1,198 @@
+function getAdjustTime(rawTime, isRawTimestamp, gpuFreq) {
+  let adjustTime = 0;
+  if (isRawTimestamp) {
+    // raw timestamp is ticks.
+    adjustTime = rawTime * 1000 / gpuFreq;
+  } else {
+    // converted GPU timestamp is ns. Converted to ms.
+    adjustTime = rawTime / 1000000;
+  }
+  return adjustTime;
+}
+
+// Data. For Profile data, lastFirst is false. For tracing data, lastFirst i
+// strue.
+async function parseGPUTrace(
+    jsonData, lastFirst = true, isRawTimestamp = true, gpuFreq) {
+  if (isRawTimestamp && gpuFreq == 0) {
+    throw 'isRawTimeStamp is true but gpuFreq is 0';
+  }
+  const traces = [];
+  let sum = 0;
+
+  let tracingGPULastFirst = 0;
+  if (lastFirst) {
+    const tracingGPUStart = jsonData[0]['query'][0];
+    const tracingGPUEnd = jsonData[jsonData.length - 1]['query'][1];
+
+    tracingGPULastFirst = getAdjustTime(
+        (tracingGPUEnd - tracingGPUStart), isRawTimestamp, gpuFreq);
+  }
+
+  for (let i = 0; i < jsonData.length; i++) {
+    let queryData = jsonData[i]['query'];
+
+    if (queryData.length == 2) {
+      queryData =
+          getAdjustTime((queryData[1] - queryData[0]), isRawTimestamp, gpuFreq);
+    } else if (queryData.length == 1) {
+      // For profile data, alreay in ms.
+      queryData = queryData[0];
+    } else {
+      console.error(
+          'Query data length ' + queryData.length + ' is not supported!');
+    }
+    sum += Number(queryData);
+    traces.push({name: jsonData[i]['name'], query: queryData});
+  }
+  sum = Number(sum).toFixed(3);
+  return [traces, sum, tracingGPULastFirst];
+}
+
+// TODO: merge this with timeline\timeline_trace.js
+function getBaseTime(rawTime, cpuTracingBase) {
+  const splitRawTime = rawTime.split(',');
+  const cpuBase = splitRawTime[2].split(':')[1];
+  const cpuFreq = splitRawTime[4].split(':')[1];
+  const gpuBase = splitRawTime[3].split(':')[1];
+  const gpuFreq = splitRawTime[5].split(':')[1];
+  // Second(s) to microsecond(us).
+  const S2US = 1000000;
+  if (cpuTracingBase != 0) {
+    // If this is used for CPU-GPU time: cpuTracingBase may possibly happens
+    // before cpuBase. We use cpuTracingBase as real base, so the diff should be
+    // applied to gpuBase.
+    const diff = cpuTracingBase - cpuBase * S2US / cpuFreq;
+    return [cpuTracingBase, gpuBase * S2US / gpuFreq + diff, gpuFreq];
+  } else {
+    // For GPU only, cpuBase is not used.
+    return [cpuBase * S2US / cpuFreq, gpuBase * S2US / gpuFreq, gpuFreq];
+  }
+}
+
+// TODO: merge this with timeline\timeline_trace.js
+/**
+ * @param traceFile The tracing file.
+ * @returns [cpuBase, gpuBase, gpuFreq].
+ */
+const eventNames = null;
+async function getBaseTimeFromTracing(traceFile = '') {
+  if (traceFile == null) {
+    console.warn('No tracing file!');
+    return [0, 0, 0];
+  }
+
+  const fsasync = require('fs').promises;
+  let jsonData = JSON.parse(await fsasync.readFile(traceFile));
+  return getBaseTimeFromTracingJson(jsonData);
+}
+
+// For timeline(html): cpuTracingBase is used to get first non-0 time.
+// For node: cpuTracingBase is not used. This is used to get freq.
+// Edit this function under src\timeline\timeline_trace.js.
+function getBaseTimeFromTracingJson(jsonData) {
+  if (jsonData == null) {
+    console.warn('No tracing file!');
+    return [0, 0, 0];
+  }
+
+  const baseTimeName =
+      'd3d12::CommandRecordingContext::ExecuteCommandList Detailed Timing';
+  let baseTime = '';
+  let cpuTracingBase = 0;
+
+  for (let event of jsonData['traceEvents']) {
+    let eventName = event['name'];
+    if (eventNames && eventNames.indexOf(eventName) >= 0) {
+      if (cpuTracingBase == 0) {
+        // This is the first none 0 ts in tracing.
+        cpuTracingBase = event['ts'];
+      }
+    }
+
+    // This is the first Detailed Timing in tracing.
+    if (eventName == baseTimeName) {
+      if (baseTime == '') {
+        baseTime = event.args['Timing'];
+      }
+    }
+    if (baseTime != '') {
+      return getBaseTime(baseTime, 0);
+    }
+  }
+  if (baseTime == '') {
+    console.warn('Tracing has no Detailed Timing!');
+  }
+  return [0, 0, 0];
+}
+
+async function createModelFromData(
+    tracingPredictTime, tracingGpuData, gpuFreq, isRawTimestamp = true,
+    profilePredictJsonData, profileJsonData) {
+  if (tracingGpuData == null) {
+    throw 'Tracing JSON data is NULL!';
+  }
+  // Model data: Tracing predict.
+  const rootDir = 'timeline\\';
+  // Ops data.
+  const repeat = tracingGpuData.length;
+  const repeatTracingDataArray = [];
+  const tracingGPULastFirstArray = [];
+  const tracingSumArray = [];
+
+  for (let i = 0; i < repeat; i++) {
+    const [tracingData, tracingSum, tracingGPULastFirst] =
+        await parseGPUTrace(tracingGpuData[i], true, isRawTimestamp, gpuFreq);
+    repeatTracingDataArray.push(tracingData);
+    tracingSumArray.push(tracingSum);
+    tracingGPULastFirstArray.push(tracingGPULastFirst);
+  }
+
+  const mergedArray = [];
+
+  const opCount = repeatTracingDataArray[0].length;
+  const LENGTH_OF_DIGITALS = 3;
+  for (let i = 0; i < opCount; i++) {
+    var line = {};
+    line['name'] = repeatTracingDataArray[0][i]['name'];
+    for (let j = 0; j < repeat; j++) {
+      if (repeatTracingDataArray[j][i]['name'] != line['name']) {
+        throw 'Name not match! Please check the GPU JSON data!';
+      }
+      line[`Query${j + 1}`] = Number(repeatTracingDataArray[j][i]['query'])
+                                  .toFixed(LENGTH_OF_DIGITALS);
+    }
+    // TODO: Add Profile support here.
+    // line[`Query${repeat}`] = profileJsonData[j];
+    mergedArray.push(line);
+  }
+  {
+    var tracingPredictTimeRow = {};
+    tracingPredictTimeRow['name'] = 'Tracing mode Predict time';
+    var tracingGPULastFirstRow = {};
+    tracingGPULastFirstRow['name'] = 'Tracing mode GPU last first';
+    var tracingSumRow = {};
+    tracingSumRow['name'] = 'Sum of Ops';
+    for (let j = 0; j < repeat; j++) {
+      tracingPredictTimeRow[`Query${j + 1}`] =
+          Number(tracingPredictTime[j]).toFixed(LENGTH_OF_DIGITALS);
+      tracingGPULastFirstRow[`Query${j + 1}`] =
+          Number(tracingGPULastFirstArray[j]).toFixed(LENGTH_OF_DIGITALS);
+      tracingSumRow[`Query${j + 1}`] =
+          Number(tracingSumArray[j]).toFixed(LENGTH_OF_DIGITALS);
+    }
+    mergedArray.unshift(tracingSumRow);
+    mergedArray.unshift(tracingGPULastFirstRow);
+    mergedArray.unshift(tracingPredictTimeRow);
+  }
+  console.log('Repeat :' + tracingGpuData.length + ', Ops: ' + opCount);
+  return mergedArray;
+}
+
+
+module.exports = {
+  parseGPUTrace: parseGPUTrace,
+  getBaseTimeFromTracing: getBaseTimeFromTracing,
+  getBaseTimeFromTracingJson: getBaseTimeFromTracingJson,
+  createModelFromData: createModelFromData,
+};

--- a/src/trace_model.js
+++ b/src/trace_model.js
@@ -10,10 +10,8 @@ function getAdjustTime(rawTime, isRawTimestamp, gpuFreq) {
   return adjustTime;
 }
 
-// Data. For Profile data, lastFirst is false. For tracing data, lastFirst i
-// strue.
-async function parseGPUTrace(
-    jsonData, lastFirst = true, isRawTimestamp = true, gpuFreq) {
+// For profile data, lastFirst is false. For tracing data, lastFirst is true.
+async function parseGPUTrace(jsonData, lastFirst, isRawTimestamp, gpuFreq) {
   if (isRawTimestamp && gpuFreq == 0) {
     throw 'isRawTimeStamp is true but gpuFreq is 0';
   }
@@ -127,14 +125,13 @@ function getBaseTimeFromTracingJson(jsonData) {
 }
 
 async function createModelFromData(
-    tracingPredictTime, tracingGpuData, gpuFreq, isRawTimestamp = true,
-    profilePredictJsonData, profileJsonData) {
+    tracingPredictTime, tracingGpuData, gpuFreq, isRawTimestamp = true) {
   if (tracingGpuData == null) {
     throw 'Tracing JSON data is NULL!';
   }
   // Model data: Tracing predict.
   const rootDir = 'timeline\\';
-  // Ops data.
+  // Op data.
   const repeat = tracingGpuData.length;
   const repeatTracingDataArray = [];
   const tracingGPULastFirstArray = [];
@@ -162,8 +159,6 @@ async function createModelFromData(
       line[`Query${j + 1}`] = Number(repeatTracingDataArray[j][i]['query'])
                                   .toFixed(LENGTH_OF_DIGITALS);
     }
-    // TODO: Add Profile support here.
-    // line[`Query${repeat}`] = profileJsonData[j];
     mergedArray.push(line);
   }
   {

--- a/src/trace_ui.js
+++ b/src/trace_ui.js
@@ -1,0 +1,108 @@
+// View.
+function createTableStart() {
+  return `<style>
+  table {
+    font-family: Arial, Helvetica, sans-serif;
+    border-collapse: collapse;
+    width: 30%;
+  }
+
+  td,
+  th {
+    border: 1px solid #ddd;
+    padding: 8px;
+  }
+
+  tr:nth-child(even) {
+    background-color: #f2f2f2;
+  }
+
+  tr:hover {
+    background-color: #ddd;
+  }
+
+  th {
+    padding-top: 12px;
+    padding-bottom: 12px;
+    text-align: left;
+    background-color: #f4fAfD;
+    color: black;
+  }
+  </style><table><thead>`;
+}
+
+function createTableEnd() {
+  return '</table>';
+}
+
+function createTableStartWithInfo(data) {
+  var header = createTableStart();
+  header += `<th>${data}</th></thead>`;
+  return header;
+}
+
+function createTableStartWithLink(data, modelName, linkInfo, tracingMode) {
+  var header = createTableStart();
+  header += createTableRowWithLink(data, modelName, linkInfo, tracingMode) +
+      '</thead>';
+  return header;
+}
+
+function createTableRows(data) {
+  var rows = '';
+  for (let element of data) {
+    rows += createTableRow(element);
+  }
+  return rows;
+}
+
+function createTableRow(data) {
+  let tr = '<tr>';
+  for (key in data) {
+    tr += `<td>${data[key]}</td>`;
+  }
+  tr += '</tr>';
+  return tr;
+}
+
+function getParaFromLinkInfo(linkInfo) {
+  let linkStr = '';
+  for (const property in linkInfo) {
+    linkStr += `&${property}=${linkInfo[property]}`;
+  }
+  return linkStr;
+}
+
+// linkinfo:  {date: 2022, gpufreq: 192000}
+function createTableRowWithLink(data, modelName, linkInfo, tracingMode) {
+  let tr = '<tr>';
+  const lintStr = getParaFromLinkInfo(linkInfo);
+  const rawTimestamp = '&rawtimestamp=true';
+  for (key in data) {
+    if (data[key] != 'name') {
+      if (tracingMode == 'all') {
+        tr += `<td><a href="./../../timeline.html?${lintStr}&${
+            rawTimestamp}&gpufile=${modelName}-${key}">${data[key]}-GPU</a>
+          <a href="./../../timeline.html?${lintStr}&${rawTimestamp}&gpufile=${
+            modelName}-${key}&cpufile=${modelName}-webgpu-trace">${
+            data[key]}-CPUGPU</a>
+          </td>`;
+      } else {
+        tr += `<td><a href="./../../timeline.html?${lintStr}&${
+            rawTimestamp}&gpufile=${modelName}-${key}">${data[key]}-GPU</a>
+          </td>`;
+      }
+    } else {
+      tr += `<td>${data[key]}</td>`;
+    }
+  }
+  tr += '</tr>';
+  return tr;
+}
+
+module.exports = {
+  createTableStartWithLink: createTableStartWithLink,
+  createTableStartWithInfo: createTableStartWithInfo,
+  createTableEnd: createTableEnd,
+  createTableRows: createTableRows
+};

--- a/src/trace_ui.js
+++ b/src/trace_ui.js
@@ -84,7 +84,7 @@ function createTableRowWithLink(data, modelName, linkInfo, tracingMode) {
         tr += `<td><a href="./../../timeline.html?${lintStr}&${
             rawTimestamp}&gpufile=${modelName}-${key}">${data[key]}-GPU</a>
           <a href="./../../timeline.html?${lintStr}&${rawTimestamp}&gpufile=${
-            modelName}-${key}&cpufile=${modelName}-webgpu-trace">${
+            modelName}-${key}&cpufile=${modelName}-${key}-tracing">${
             data[key]}-CPUGPU</a>
           </td>`;
       } else {

--- a/src/trace_ui.js
+++ b/src/trace_ui.js
@@ -76,19 +76,16 @@ function getParaFromLinkInfo(linkInfo) {
 // linkinfo:  {date: 2022, gpufreq: 192000}
 function createTableRowWithLink(data, modelName, linkInfo, tracingMode) {
   let tr = '<tr>';
-  const lintStr = getParaFromLinkInfo(linkInfo);
+  const linkStr = getParaFromLinkInfo(linkInfo);
   const rawTimestamp = '&rawtimestamp=true';
   for (key in data) {
     if (data[key] != 'name') {
       if (tracingMode == 'all') {
-        tr += `<td><a href="./../../timeline.html?${lintStr}&${
-            rawTimestamp}&gpufile=${modelName}-${key}">${data[key]}-GPU</a>
-          <a href="./../../timeline.html?${lintStr}&${rawTimestamp}&gpufile=${
-            modelName}-${key}&cpufile=${modelName}-${key}-tracing">${
-            data[key]}-CPUGPU</a>
+        tr += `<td><a href="./../../timeline.html?${linkStr}&${
+            rawTimestamp}&trace=${modelName}-${key}">${data[key]}</a>
           </td>`;
       } else {
-        tr += `<td><a href="./../../timeline.html?${lintStr}&${
+        tr += `<td><a href="./../../timeline.html?${linkStr}&${
             rawTimestamp}&gpufile=${modelName}-${key}">${data[key]}-GPU</a>
           </td>`;
       }

--- a/src/trace_util.js
+++ b/src/trace_util.js
@@ -61,7 +61,10 @@ async function readFileAsync(fileName) {
 }
 
 
-function pushEvents(results, runCount, event) {
+function pushEvents(results, runCount, event, inModel) {
+  if (!inModel) {
+    return;
+  }
   if (!(runCount in results)) {
     results[runCount] = [];
   }
@@ -110,17 +113,17 @@ async function splitTraceByModel(traceFile, modelSummarDir) {
       if (jsMessageName == modelBeginMessage) {
         runCount++;
         inModel = true;
-        if (inModel) pushEvents(results, runCount, event);
+        pushEvents(results, runCount, event, inModel);
       } else if (jsMessageName == modelEndMessage) {
-        if (inModel) pushEvents(results, runCount, event);
+        pushEvents(results, runCount, event, inModel);
         inModel = false;
       } else {
-        if (inModel) pushEvents(results, runCount, event);
+        pushEvents(results, runCount, event, inModel);
       }
     } else if (eventName == dawnTimestampName) {
-      if (inModel) pushEvents(results, runCount, event);
+      pushEvents(results, runCount, event, inModel);
     } else if (eventNames.indexOf(eventName) >= 0) {
-      if (inModel) pushEvents(results, runCount, event);
+      pushEvents(results, runCount, event, inModel);
     }
   }
   return [results, traceEnd];

--- a/src/trace_util.js
+++ b/src/trace_util.js
@@ -69,7 +69,7 @@ function pushEvents(results, runCount, event) {
   results[runCount].push(event);
 }
 
-async function splitTracingByModel(traceFile, modelSummarDir) {
+async function splitTraceByModel(traceFile, modelSummarDir) {
   const eventNames = [
     'DeviceBase::APICreateComputePipeline',
     'CreateComputePipelineAsyncTask::Run', 'DeviceBase::APICreateShaderModule',
@@ -102,7 +102,6 @@ async function splitTracingByModel(traceFile, modelSummarDir) {
       jsMessageName = event['args']['data']['message'];
     }
 
-    // For console.timeStamp. {data: [{name: 'xxxx', xAxis: 9}]},
     const modelBeginMessage = 'predict';
     const modelEndMessage = 'JSGetKernelTimesEnd';
     const eventJSTimestampNameIndex =
@@ -132,5 +131,5 @@ module.exports = {
   getModelNames: getModelNames,
   getModelNamesFromLog: getModelNamesFromLog,
   getAverageInfoFromLog: getAverageInfoFromLog,
-  splitTracingByModel: splitTracingByModel,
+  splitTraceByModel: splitTraceByModel,
 };

--- a/src/trace_util.js
+++ b/src/trace_util.js
@@ -69,7 +69,7 @@ function pushEvents(results, runCount, event) {
   results[runCount].push(event);
 }
 
-async function splitTracingByModel(traceFile, modelNames, modelSummarDir) {
+async function splitTracingByModel(traceFile, modelSummarDir) {
   const eventNames = [
     'DeviceBase::APICreateComputePipeline',
     'CreateComputePipelineAsyncTask::Run', 'DeviceBase::APICreateShaderModule',
@@ -124,19 +124,7 @@ async function splitTracingByModel(traceFile, modelNames, modelSummarDir) {
       if (inModel) pushEvents(results, runCount, event);
     }
   }
-  const runPerModel = results.length / modelNames.length;
-  for (let j = 0; j < modelNames.length; j++) {
-    for (let i = 0; i < runPerModel; i++) {
-      let result = {
-        'traceEvents': results[j * runPerModel + i],
-        'metadata': traceEnd
-      };
-      var fs = require('fs');
-      fs.writeFileSync(
-          `${modelSummarDir}/${modelNames[j]}-${i + 1}-tracing.json`,
-          JSON.stringify(result));
-    }
-  }
+  return [results, traceEnd];
 }
 
 module.exports = {

--- a/src/trace_util.js
+++ b/src/trace_util.js
@@ -1,0 +1,63 @@
+function getJsonFromString(str, start, end) {
+  const regStr = String.raw`${start}.*?${end}`;
+  var matchRegex = new RegExp(regStr, 'g');
+  const matchResults = str.match(matchRegex);
+  if (Array.isArray(matchResults)) {
+    var results = [];
+    for (const item of matchResults) {
+      results.push(JSON.parse(item.replace(start, '').replace(end, '')));
+    }
+    return results;
+  } else {
+    if (matchResults == null) throw new Error('Please make sure log is valid!');
+    return new Array(
+        JSON.parse(matchResults.replace(start, '').replace(end, '')));
+  }
+}
+
+function getModelNames(modelNamesJson) {
+  if (modelNamesJson == null) {
+    console.error('No Model names!');
+    return [];
+  }
+  const modelNames = [];
+  for (const item in modelNamesJson['performance']) {
+    modelNames.push(modelNamesJson['performance'][item][0].replace(/ /g, '_'));
+  }
+  return modelNames;
+}
+
+// Make name simple.
+function getName(item) {
+  return item.replace(/[\[\]]/g, '').replace(/\//g, '_').replace(/[,\s]/g, '-');
+}
+
+function getModelNamesFromLog(logStr) {
+  const matchRegex = /\[\d{1,2}\/\d{1,2}\].*webgpu/g;
+  const matchResults = logStr.match(matchRegex);
+
+  if (Array.isArray(matchResults)) {
+    var results = [];
+    for (const item of matchResults) {
+      const name = getName(item);
+      results.push(name);
+    }
+    return results;
+  } else {
+    return getName(matchResults);
+  }
+}
+
+function getAverageInfoFromLog(logStr) {
+  // TODO: This regex takes too long.
+  const matchRegex = /.*\[object Object\]/g;
+  const matchResults = logStr.match(matchRegex);
+  return matchResults;
+}
+
+module.exports = {
+  getJsonFromString: getJsonFromString,
+  getModelNames: getModelNames,
+  getModelNamesFromLog: getModelNamesFromLog,
+  getAverageInfoFromLog: getAverageInfoFromLog,
+};

--- a/src/util.js
+++ b/src/util.js
@@ -70,6 +70,7 @@ module.exports = {
   'benchmarkUrlArgs': 'WEBGL_USE_SHAPES_UNIFORMS=true&CHECK_COMPUTATION_FOR_ERRORS=false',
   'demoUrl': 'https://wp-27.sh.intel.com/workspace/project/tfjswebgpu/tfjs-models/pose-detection/demos',
   'timeout': 180 * 1000,
+  'gpufreqTraceFile': '',
   capitalize: capitalize,
   getDuration: getDuration,
   log: log,

--- a/src/util.js
+++ b/src/util.js
@@ -58,6 +58,10 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function getTraceFlag() {
+ return 'trace' in this.args || 'trace-category' in this.args;
+}
+
 module.exports = {
   'browserArgs': '--enable-unsafe-webgpu --disable-dawn-features=disallow_unsafe_apis --enable-features=WebAssemblyThreads,SharedArrayBuffer,WebAssemblySimd,MediaFoundationD3D11VideoCapture --start-maximized',
   'hostname': os.hostname(),
@@ -76,4 +80,5 @@ module.exports = {
   log: log,
   sleep: sleep,
   uncapitalize: uncapitalize,
+  getTraceFlag: getTraceFlag,
 };


### PR DESCRIPTION
Steps for how to get trace data:

1) Before run any commands below, git clone https://github.com/tensorflow/tfjs/pull/6339/ first, then setup it with npx-httpserver.

2) Use webtest to CPU-GPU timeline data.
node src/main.js --target performance --performance-backend webgpu --benchmark-url https://127.0.0.1:8080/tfjs/e2e/benchmarks/local-benchmark/ --trace --benchmark bodypix

     To get warmup trace, add: --warmup-times 0 --run-times 1

3) copy data from webtest\out to timeline. Then setup a web server under timeline.