### PR TITLE
Enable CPU GPU timeline

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -146,7 +146,7 @@ util.args = yargs
   })
   .option('trace', {
     type: 'string',
-    describe: 'Enable tracing',
+    describe: 'Enable trace',
   })
   .option('unit-backend', {
     type: 'string',
@@ -324,7 +324,7 @@ async function main() {
       util.args['trace-category'] = 'disabled-by-default-gpu.dawn';
     }
     util.args['disable-breakdown'] = true;
-    util.benchmarkUrlArgs +=`&tracing=${trace}`;
+    util.benchmarkUrlArgs +=`&trace=${trace}`;
   }
 
   let results = {};

--- a/src/trace.js
+++ b/src/trace.js
@@ -1,34 +1,118 @@
-'use strict';
-
+const {createModelFromData, getBaseTimeFromTracing} =
+    require('./trace_model.js');
+const {
+  createTableStartWithLink,
+  createTableStartWithInfo,
+  createTableEnd,
+  createTableRows
+} = require('./trace_ui.js');
+const {
+  getJsonFromString,
+  getModelNames,
+  getModelNamesFromLog,
+  getAverageInfoFromLog,
+  splitTraceByModel,
+} = require('./trace_util.js');
 const fs = require('fs');
-const path = require('path');
-const util = require('./util.js');
+const fsasync = require('fs').promises;
 
-function parseTrace(traceFile = '', totalTime = 0) {
-  let eventNames = ['DeviceBase::APICreateComputePipeline', 'CreateComputePipelineAsyncTask::Run', 'DeviceBase::APICreateShaderModule'];
-  let results = {};
-  let base_ts = 0;
+function updateUI(tableName, mergedData, modelName, linkInfo, tracingMode) {
+  // Update UI.
+  let modelTable = createTableStartWithInfo(tableName);
 
-  if (!traceFile) {
-    traceFile = `${util.outDir}/${util.args['trace-file']}.json`;
-  }
-  let jsonData = JSON.parse(fs.readFileSync(traceFile));
-  for (let event of jsonData['traceEvents']) {
-    let eventName = event['name']
-    if (eventNames.indexOf(eventName) >= 0) {
-      if (base_ts == 0) {
-        base_ts = event['ts'];
-      }
-      if (!(eventName in results)) {
-        results[eventName] = [];
-      }
-      results[eventName].push([(event['ts'] - base_ts) / 1000, event['dur'] / 1000]);
-    }
-  }
-  results['total'] = [[0, totalTime]];
-  console.log(results);
-  let timelineFile = traceFile.replace('-trace', '');
-  fs.writeFileSync(timelineFile, JSON.stringify(results));
+  modelTable += createTableEnd();
+
+  let table = '';
+  let headdata = Object.keys(mergedData[0]);
+  table += createTableStartWithLink(headdata, modelName, linkInfo, tracingMode);
+  table += createTableRows(mergedData);
+  table += createTableEnd();
+  return modelTable + table;
 }
 
-module.exports = parseTrace;
+async function singleModelSummary(
+    tabelName, tracingPredictTime, tracingGpuData, modelName, linkInfo, gpuFreq,
+    tracingMode, profilePredictJsonData = null, profileJsonData = null) {
+  const mergedData = await createModelFromData(
+      tracingPredictTime, tracingGpuData, gpuFreq, true, profilePredictJsonData,
+      profileJsonData);
+  return updateUI(tabelName, mergedData, modelName, linkInfo, tracingMode);
+}
+
+async function modelSummary(
+    modelSummarDir, logfileName, results, benchmarkUrlArgs, gpuFreqTracingFile,
+    tracingMode) {
+  if (logfileName == null) {
+    console.error('No log file!');
+  }
+  console.log('logfileName = ' + logfileName);
+  const logStr = await fsasync.readFile(logfileName, 'binary');
+  const modelNames =
+      results == null ? getModelNamesFromLog(logStr) : getModelNames(results);
+
+  const averageInfos = getAverageInfoFromLog(logStr);
+  const predictJsonData =
+      getJsonFromString(logStr, 'predictbegin', 'predictend');
+  const gpuJsonData = getJsonFromString(logStr, 'gpudatabegin', 'gpudataend');
+
+  const [, , gpuFreq] = gpuFreqTracingFile ?
+      await getBaseTimeFromTracing(gpuFreqTracingFile) :
+      [0, 0, 19200000];
+  console.log('GPU Frequency: ' + gpuFreq);
+
+  let html = `<div>${benchmarkUrlArgs}</div>`;
+  const splitLogfileName = logfileName.split('\\');
+  const date = splitLogfileName[splitLogfileName.length - 1].split('.')[0];
+  const linkInfo = {
+    date: date,
+    gpufreq: gpuFreq,
+    benchmarkUrlArgs: benchmarkUrlArgs
+  };
+
+  // predictJsonData.length is the model number.
+  const modelCount = predictJsonData.length;
+  for (var i = 0; i < modelCount; i++) {
+    // Tracing may possible be repeated. predictJsonData[0]['times'].length
+    // is the repeat count.
+    const repeat = predictJsonData[0]['times'].length;
+    const modelName = modelSummarDir + '\\' + modelNames[i];
+    const tracingPredictTimes = predictJsonData[i]['times'];
+    const gpuJsonDataForModel = gpuJsonData.slice(i * repeat, (i + 1) * repeat);
+    html += await singleModelSummary(
+        modelNames[i].split('-')[0] + '-' +
+            averageInfos[i].replace('[object Object]', ''),
+        tracingPredictTimes, gpuJsonDataForModel, modelNames[i], linkInfo,
+        gpuFreq, tracingMode);
+
+    const [tracingForModel, traceEnd] = await splitTraceByModel(
+        `${modelNames[i]}-webgpu-trace.json`, modelSummarDir);
+    if (tracingForModel.length != repeat) {
+      throw new Error(`${modelNames[i]} length of tracing for model(${
+          tracingForModel.length}) doesn\'t equals GPU length(${repeat})`);
+    }
+    for (var j = 0; j < repeat; j++) {
+      const name = modelName + '-' + (j + 1);
+      const dataForGPU = gpuJsonData[i * repeat + j];
+
+      const dataForTracing = {
+        'traceEvents': tracingForModel[j],
+        'metadata': traceEnd
+      };
+      const dataForModel = {'trace': dataForTracing, 'gpu': dataForGPU};
+      fs.writeFileSync(`${name}.json`, JSON.stringify(dataForModel));
+    }
+
+    fs.writeFileSync(
+        modelName + '-predict.json', JSON.stringify(predictJsonData[i]));
+  }
+
+  const isRawTimestamp = true;
+  const modelSummaryFile = modelSummarDir + '\\' + date + '-raw' +
+      isRawTimestamp + '-modelsummary.html';
+  console.log(modelSummaryFile);
+  fs.writeFileSync(modelSummaryFile, html);
+}
+
+module.exports = {
+  modelSummary: modelSummary
+};

--- a/src/trace_model.js
+++ b/src/trace_model.js
@@ -10,7 +10,7 @@ function getAdjustTime(rawTime, isRawTimestamp, gpuFreq) {
   return adjustTime;
 }
 
-// For profile data, lastFirst is false. For tracing data, lastFirst is true.
+// For profile data, lastFirst is false. For trace data, lastFirst is true.
 async function parseGPUTrace(jsonData, lastFirst, isRawTimestamp, gpuFreq) {
   if (isRawTimestamp && gpuFreq == 0) {
     throw 'isRawTimeStamp is true but gpuFreq is 0';
@@ -18,13 +18,13 @@ async function parseGPUTrace(jsonData, lastFirst, isRawTimestamp, gpuFreq) {
   const traces = [];
   let sum = 0;
 
-  let tracingGPULastFirst = 0;
+  let traceGPULastFirst = 0;
   if (lastFirst) {
-    const tracingGPUStart = jsonData[0]['query'][0];
-    const tracingGPUEnd = jsonData[jsonData.length - 1]['query'][1];
+    const traceGPUStart = jsonData[0]['query'][0];
+    const traceGPUEnd = jsonData[jsonData.length - 1]['query'][1];
 
-    tracingGPULastFirst = getAdjustTime(
-        (tracingGPUEnd - tracingGPUStart), isRawTimestamp, gpuFreq);
+    traceGPULastFirst =
+        getAdjustTime((traceGPUEnd - traceGPUStart), isRawTimestamp, gpuFreq);
   }
 
   for (let i = 0; i < jsonData.length; i++) {
@@ -44,11 +44,11 @@ async function parseGPUTrace(jsonData, lastFirst, isRawTimestamp, gpuFreq) {
     traces.push({name: jsonData[i]['name'], query: queryData});
   }
   sum = Number(sum).toFixed(3);
-  return [traces, sum, tracingGPULastFirst];
+  return [traces, sum, traceGPULastFirst];
 }
 
 // TODO: merge this with timeline\timeline_trace.js
-function getBaseTime(rawTime, cpuTracingBase) {
+function getBaseTime(rawTime, cpuTraceBase) {
   const splitRawTime = rawTime.split(',');
   const cpuBase = splitRawTime[2].split(':')[1];
   const cpuFreq = splitRawTime[4].split(':')[1];
@@ -56,12 +56,12 @@ function getBaseTime(rawTime, cpuTracingBase) {
   const gpuFreq = splitRawTime[5].split(':')[1];
   // Second(s) to microsecond(us).
   const S2US = 1000000;
-  if (cpuTracingBase != 0) {
-    // If this is used for CPU-GPU time: cpuTracingBase may possibly happens
-    // before cpuBase. We use cpuTracingBase as real base, so the diff should be
+  if (cpuTraceBase != 0) {
+    // If this is used for CPU-GPU time: cpuTraceBase may possibly happens
+    // before cpuBase. We use cpuTraceBase as real base, so the diff should be
     // applied to gpuBase.
-    const diff = cpuTracingBase - cpuBase * S2US / cpuFreq;
-    return [cpuTracingBase, gpuBase * S2US / gpuFreq + diff, gpuFreq];
+    const diff = cpuTraceBase - cpuBase * S2US / cpuFreq;
+    return [cpuTraceBase, gpuBase * S2US / gpuFreq + diff, gpuFreq];
   } else {
     // For GPU only, cpuBase is not used.
     return [cpuBase * S2US / cpuFreq, gpuBase * S2US / gpuFreq, gpuFreq];
@@ -70,45 +70,45 @@ function getBaseTime(rawTime, cpuTracingBase) {
 
 // TODO: merge this with timeline\timeline_trace.js
 /**
- * @param traceFile The tracing file.
+ * @param traceFile The trace file.
  * @returns [cpuBase, gpuBase, gpuFreq].
  */
 const eventNames = null;
-async function getBaseTimeFromTracing(traceFile = '') {
+async function getBaseTimeFromTrace(traceFile = '') {
   if (traceFile == null) {
-    console.warn('No tracing file!');
+    console.warn('No trace file!');
     return [0, 0, 0];
   }
 
   const fsasync = require('fs').promises;
   let jsonData = JSON.parse(await fsasync.readFile(traceFile));
-  return getBaseTimeFromTracingJson(jsonData);
+  return getBaseTimeFromTraceJson(jsonData);
 }
 
-// For timeline(html): cpuTracingBase is used to get first non-0 time.
-// For node: cpuTracingBase is not used. This is used to get freq.
+// For timeline(html): cpuTraceBase is used to get first non-0 time.
+// For node: cpuTraceBase is not used. This is used to get freq.
 // Edit this function under src\timeline\timeline_trace.js.
-function getBaseTimeFromTracingJson(jsonData) {
+function getBaseTimeFromTraceJson(jsonData) {
   if (jsonData == null) {
-    console.warn('No tracing file!');
+    console.warn('No trace file!');
     return [0, 0, 0];
   }
 
   const baseTimeName =
       'd3d12::CommandRecordingContext::ExecuteCommandList Detailed Timing';
   let baseTime = '';
-  let cpuTracingBase = 0;
+  let cpuTraceBase = 0;
 
   for (let event of jsonData['traceEvents']) {
     let eventName = event['name'];
     if (eventNames && eventNames.indexOf(eventName) >= 0) {
-      if (cpuTracingBase == 0) {
-        // This is the first none 0 ts in tracing.
-        cpuTracingBase = event['ts'];
+      if (cpuTraceBase == 0) {
+        // This is the first none 0 ts in trace.
+        cpuTraceBase = event['ts'];
       }
     }
 
-    // This is the first Detailed Timing in tracing.
+    // This is the first Detailed Timing in trace.
     if (eventName == baseTimeName) {
       if (baseTime == '') {
         baseTime = event.args['Timing'];
@@ -119,75 +119,75 @@ function getBaseTimeFromTracingJson(jsonData) {
     }
   }
   if (baseTime == '') {
-    console.warn('Tracing has no Detailed Timing!');
+    console.warn('Trace has no Detailed Timing!');
   }
   return [0, 0, 0];
 }
 
 async function createModelFromData(
-    tracingPredictTime, tracingGpuData, gpuFreq, isRawTimestamp = true) {
-  if (tracingGpuData == null) {
-    throw 'Tracing JSON data is NULL!';
+    tracePredictTime, traceGpuData, gpuFreq, isRawTimestamp = true) {
+  if (traceGpuData == null) {
+    throw 'Trace JSON data is NULL!';
   }
-  // Model data: Tracing predict.
+  // Model data: Trace predict.
   const rootDir = 'timeline\\';
   // Op data.
-  const repeat = tracingGpuData.length;
-  const repeatTracingDataArray = [];
-  const tracingGPULastFirstArray = [];
-  const tracingSumArray = [];
+  const repeat = traceGpuData.length;
+  const repeatTraceDataArray = [];
+  const traceGPULastFirstArray = [];
+  const traceSumArray = [];
 
   for (let i = 0; i < repeat; i++) {
-    const [tracingData, tracingSum, tracingGPULastFirst] =
-        await parseGPUTrace(tracingGpuData[i], true, isRawTimestamp, gpuFreq);
-    repeatTracingDataArray.push(tracingData);
-    tracingSumArray.push(tracingSum);
-    tracingGPULastFirstArray.push(tracingGPULastFirst);
+    const [traceData, traceSum, traceGPULastFirst] =
+        await parseGPUTrace(traceGpuData[i], true, isRawTimestamp, gpuFreq);
+    repeatTraceDataArray.push(traceData);
+    traceSumArray.push(traceSum);
+    traceGPULastFirstArray.push(traceGPULastFirst);
   }
 
   const mergedArray = [];
 
-  const opCount = repeatTracingDataArray[0].length;
+  const opCount = repeatTraceDataArray[0].length;
   const LENGTH_OF_DIGITALS = 3;
   for (let i = 0; i < opCount; i++) {
     var line = {};
-    line['name'] = repeatTracingDataArray[0][i]['name'];
+    line['name'] = repeatTraceDataArray[0][i]['name'];
     for (let j = 0; j < repeat; j++) {
-      if (repeatTracingDataArray[j][i]['name'] != line['name']) {
+      if (repeatTraceDataArray[j][i]['name'] != line['name']) {
         throw 'Name not match! Please check the GPU JSON data!';
       }
-      line[`Query${j + 1}`] = Number(repeatTracingDataArray[j][i]['query'])
+      line[`Query${j + 1}`] = Number(repeatTraceDataArray[j][i]['query'])
                                   .toFixed(LENGTH_OF_DIGITALS);
     }
     mergedArray.push(line);
   }
   {
-    var tracingPredictTimeRow = {};
-    tracingPredictTimeRow['name'] = 'Tracing mode Predict time';
-    var tracingGPULastFirstRow = {};
-    tracingGPULastFirstRow['name'] = 'Tracing mode GPU last first';
-    var tracingSumRow = {};
-    tracingSumRow['name'] = 'Sum of Ops';
+    var tracePredictTimeRow = {};
+    tracePredictTimeRow['name'] = 'Trace mode Predict time';
+    var traceGPULastFirstRow = {};
+    traceGPULastFirstRow['name'] = 'Trace mode GPU last first';
+    var traceSumRow = {};
+    traceSumRow['name'] = 'Sum of Ops';
     for (let j = 0; j < repeat; j++) {
-      tracingPredictTimeRow[`Query${j + 1}`] =
-          Number(tracingPredictTime[j]).toFixed(LENGTH_OF_DIGITALS);
-      tracingGPULastFirstRow[`Query${j + 1}`] =
-          Number(tracingGPULastFirstArray[j]).toFixed(LENGTH_OF_DIGITALS);
-      tracingSumRow[`Query${j + 1}`] =
-          Number(tracingSumArray[j]).toFixed(LENGTH_OF_DIGITALS);
+      tracePredictTimeRow[`Query${j + 1}`] =
+          Number(tracePredictTime[j]).toFixed(LENGTH_OF_DIGITALS);
+      traceGPULastFirstRow[`Query${j + 1}`] =
+          Number(traceGPULastFirstArray[j]).toFixed(LENGTH_OF_DIGITALS);
+      traceSumRow[`Query${j + 1}`] =
+          Number(traceSumArray[j]).toFixed(LENGTH_OF_DIGITALS);
     }
-    mergedArray.unshift(tracingSumRow);
-    mergedArray.unshift(tracingGPULastFirstRow);
-    mergedArray.unshift(tracingPredictTimeRow);
+    mergedArray.unshift(traceSumRow);
+    mergedArray.unshift(traceGPULastFirstRow);
+    mergedArray.unshift(tracePredictTimeRow);
   }
-  console.log('Repeat :' + tracingGpuData.length + ', Ops: ' + opCount);
+  console.log('Repeat :' + traceGpuData.length + ', Ops: ' + opCount);
   return mergedArray;
 }
 
 
 module.exports = {
   parseGPUTrace: parseGPUTrace,
-  getBaseTimeFromTracing: getBaseTimeFromTracing,
-  getBaseTimeFromTracingJson: getBaseTimeFromTracingJson,
+  getBaseTimeFromTrace: getBaseTimeFromTrace,
+  getBaseTimeFromTraceJson: getBaseTimeFromTraceJson,
   createModelFromData: createModelFromData,
 };

--- a/src/trace_model.js
+++ b/src/trace_model.js
@@ -1,0 +1,193 @@
+function getAdjustTime(rawTime, isRawTimestamp, gpuFreq) {
+  let adjustTime = 0;
+  if (isRawTimestamp) {
+    // raw timestamp is ticks.
+    adjustTime = rawTime * 1000 / gpuFreq;
+  } else {
+    // converted GPU timestamp is ns. Converted to ms.
+    adjustTime = rawTime / 1000000;
+  }
+  return adjustTime;
+}
+
+// For profile data, lastFirst is false. For tracing data, lastFirst is true.
+async function parseGPUTrace(jsonData, lastFirst, isRawTimestamp, gpuFreq) {
+  if (isRawTimestamp && gpuFreq == 0) {
+    throw 'isRawTimeStamp is true but gpuFreq is 0';
+  }
+  const traces = [];
+  let sum = 0;
+
+  let tracingGPULastFirst = 0;
+  if (lastFirst) {
+    const tracingGPUStart = jsonData[0]['query'][0];
+    const tracingGPUEnd = jsonData[jsonData.length - 1]['query'][1];
+
+    tracingGPULastFirst = getAdjustTime(
+        (tracingGPUEnd - tracingGPUStart), isRawTimestamp, gpuFreq);
+  }
+
+  for (let i = 0; i < jsonData.length; i++) {
+    let queryData = jsonData[i]['query'];
+
+    if (queryData.length == 2) {
+      queryData =
+          getAdjustTime((queryData[1] - queryData[0]), isRawTimestamp, gpuFreq);
+    } else if (queryData.length == 1) {
+      // For profile data, alreay in ms.
+      queryData = queryData[0];
+    } else {
+      console.error(
+          'Query data length ' + queryData.length + ' is not supported!');
+    }
+    sum += Number(queryData);
+    traces.push({name: jsonData[i]['name'], query: queryData});
+  }
+  sum = Number(sum).toFixed(3);
+  return [traces, sum, tracingGPULastFirst];
+}
+
+// TODO: merge this with timeline\timeline_trace.js
+function getBaseTime(rawTime, cpuTracingBase) {
+  const splitRawTime = rawTime.split(',');
+  const cpuBase = splitRawTime[2].split(':')[1];
+  const cpuFreq = splitRawTime[4].split(':')[1];
+  const gpuBase = splitRawTime[3].split(':')[1];
+  const gpuFreq = splitRawTime[5].split(':')[1];
+  // Second(s) to microsecond(us).
+  const S2US = 1000000;
+  if (cpuTracingBase != 0) {
+    // If this is used for CPU-GPU time: cpuTracingBase may possibly happens
+    // before cpuBase. We use cpuTracingBase as real base, so the diff should be
+    // applied to gpuBase.
+    const diff = cpuTracingBase - cpuBase * S2US / cpuFreq;
+    return [cpuTracingBase, gpuBase * S2US / gpuFreq + diff, gpuFreq];
+  } else {
+    // For GPU only, cpuBase is not used.
+    return [cpuBase * S2US / cpuFreq, gpuBase * S2US / gpuFreq, gpuFreq];
+  }
+}
+
+// TODO: merge this with timeline\timeline_trace.js
+/**
+ * @param traceFile The tracing file.
+ * @returns [cpuBase, gpuBase, gpuFreq].
+ */
+const eventNames = null;
+async function getBaseTimeFromTracing(traceFile = '') {
+  if (traceFile == null) {
+    console.warn('No tracing file!');
+    return [0, 0, 0];
+  }
+
+  const fsasync = require('fs').promises;
+  let jsonData = JSON.parse(await fsasync.readFile(traceFile));
+  return getBaseTimeFromTracingJson(jsonData);
+}
+
+// For timeline(html): cpuTracingBase is used to get first non-0 time.
+// For node: cpuTracingBase is not used. This is used to get freq.
+// Edit this function under src\timeline\timeline_trace.js.
+function getBaseTimeFromTracingJson(jsonData) {
+  if (jsonData == null) {
+    console.warn('No tracing file!');
+    return [0, 0, 0];
+  }
+
+  const baseTimeName =
+      'd3d12::CommandRecordingContext::ExecuteCommandList Detailed Timing';
+  let baseTime = '';
+  let cpuTracingBase = 0;
+
+  for (let event of jsonData['traceEvents']) {
+    let eventName = event['name'];
+    if (eventNames && eventNames.indexOf(eventName) >= 0) {
+      if (cpuTracingBase == 0) {
+        // This is the first none 0 ts in tracing.
+        cpuTracingBase = event['ts'];
+      }
+    }
+
+    // This is the first Detailed Timing in tracing.
+    if (eventName == baseTimeName) {
+      if (baseTime == '') {
+        baseTime = event.args['Timing'];
+      }
+    }
+    if (baseTime != '') {
+      return getBaseTime(baseTime, 0);
+    }
+  }
+  if (baseTime == '') {
+    console.warn('Tracing has no Detailed Timing!');
+  }
+  return [0, 0, 0];
+}
+
+async function createModelFromData(
+    tracingPredictTime, tracingGpuData, gpuFreq, isRawTimestamp = true) {
+  if (tracingGpuData == null) {
+    throw 'Tracing JSON data is NULL!';
+  }
+  // Model data: Tracing predict.
+  const rootDir = 'timeline\\';
+  // Op data.
+  const repeat = tracingGpuData.length;
+  const repeatTracingDataArray = [];
+  const tracingGPULastFirstArray = [];
+  const tracingSumArray = [];
+
+  for (let i = 0; i < repeat; i++) {
+    const [tracingData, tracingSum, tracingGPULastFirst] =
+        await parseGPUTrace(tracingGpuData[i], true, isRawTimestamp, gpuFreq);
+    repeatTracingDataArray.push(tracingData);
+    tracingSumArray.push(tracingSum);
+    tracingGPULastFirstArray.push(tracingGPULastFirst);
+  }
+
+  const mergedArray = [];
+
+  const opCount = repeatTracingDataArray[0].length;
+  const LENGTH_OF_DIGITALS = 3;
+  for (let i = 0; i < opCount; i++) {
+    var line = {};
+    line['name'] = repeatTracingDataArray[0][i]['name'];
+    for (let j = 0; j < repeat; j++) {
+      if (repeatTracingDataArray[j][i]['name'] != line['name']) {
+        throw 'Name not match! Please check the GPU JSON data!';
+      }
+      line[`Query${j + 1}`] = Number(repeatTracingDataArray[j][i]['query'])
+                                  .toFixed(LENGTH_OF_DIGITALS);
+    }
+    mergedArray.push(line);
+  }
+  {
+    var tracingPredictTimeRow = {};
+    tracingPredictTimeRow['name'] = 'Tracing mode Predict time';
+    var tracingGPULastFirstRow = {};
+    tracingGPULastFirstRow['name'] = 'Tracing mode GPU last first';
+    var tracingSumRow = {};
+    tracingSumRow['name'] = 'Sum of Ops';
+    for (let j = 0; j < repeat; j++) {
+      tracingPredictTimeRow[`Query${j + 1}`] =
+          Number(tracingPredictTime[j]).toFixed(LENGTH_OF_DIGITALS);
+      tracingGPULastFirstRow[`Query${j + 1}`] =
+          Number(tracingGPULastFirstArray[j]).toFixed(LENGTH_OF_DIGITALS);
+      tracingSumRow[`Query${j + 1}`] =
+          Number(tracingSumArray[j]).toFixed(LENGTH_OF_DIGITALS);
+    }
+    mergedArray.unshift(tracingSumRow);
+    mergedArray.unshift(tracingGPULastFirstRow);
+    mergedArray.unshift(tracingPredictTimeRow);
+  }
+  console.log('Repeat :' + tracingGpuData.length + ', Ops: ' + opCount);
+  return mergedArray;
+}
+
+
+module.exports = {
+  parseGPUTrace: parseGPUTrace,
+  getBaseTimeFromTracing: getBaseTimeFromTracing,
+  getBaseTimeFromTracingJson: getBaseTimeFromTracingJson,
+  createModelFromData: createModelFromData,
+};

--- a/src/trace_ui.js
+++ b/src/trace_ui.js
@@ -1,0 +1,105 @@
+// View.
+function createTableStart() {
+  return `<style>
+  table {
+    font-family: Arial, Helvetica, sans-serif;
+    border-collapse: collapse;
+    width: 30%;
+  }
+
+  td,
+  th {
+    border: 1px solid #ddd;
+    padding: 8px;
+  }
+
+  tr:nth-child(even) {
+    background-color: #f2f2f2;
+  }
+
+  tr:hover {
+    background-color: #ddd;
+  }
+
+  th {
+    padding-top: 12px;
+    padding-bottom: 12px;
+    text-align: left;
+    background-color: #f4fAfD;
+    color: black;
+  }
+  </style><table><thead>`;
+}
+
+function createTableEnd() {
+  return '</table>';
+}
+
+function createTableStartWithInfo(data) {
+  var header = createTableStart();
+  header += `<th>${data}</th></thead>`;
+  return header;
+}
+
+function createTableStartWithLink(data, modelName, linkInfo, tracingMode) {
+  var header = createTableStart();
+  header += createTableRowWithLink(data, modelName, linkInfo, tracingMode) +
+      '</thead>';
+  return header;
+}
+
+function createTableRows(data) {
+  var rows = '';
+  for (let element of data) {
+    rows += createTableRow(element);
+  }
+  return rows;
+}
+
+function createTableRow(data) {
+  let tr = '<tr>';
+  for (key in data) {
+    tr += `<td>${data[key]}</td>`;
+  }
+  tr += '</tr>';
+  return tr;
+}
+
+function getParaFromLinkInfo(linkInfo) {
+  let linkStr = '';
+  for (const property in linkInfo) {
+    linkStr += `&${property}=${linkInfo[property]}`;
+  }
+  return linkStr;
+}
+
+// linkinfo:  {date: 2022, gpufreq: 192000}
+function createTableRowWithLink(data, modelName, linkInfo, tracingMode) {
+  let tr = '<tr>';
+  const linkStr = getParaFromLinkInfo(linkInfo);
+  const rawTimestamp = '&rawtimestamp=true';
+  for (key in data) {
+    if (data[key] != 'name') {
+      if (tracingMode == 'all') {
+        tr += `<td><a href="./../../timeline.html?${linkStr}&${
+            rawTimestamp}&trace=${modelName}-${key}">${data[key]}</a>
+          </td>`;
+      } else {
+        tr += `<td><a href="./../../timeline.html?${linkStr}&${
+            rawTimestamp}&gpufile=${modelName}-${key}">${data[key]}-GPU</a>
+          </td>`;
+      }
+    } else {
+      tr += `<td>${data[key]}</td>`;
+    }
+  }
+  tr += '</tr>';
+  return tr;
+}
+
+module.exports = {
+  createTableStartWithLink: createTableStartWithLink,
+  createTableStartWithInfo: createTableStartWithInfo,
+  createTableEnd: createTableEnd,
+  createTableRows: createTableRows
+};

--- a/src/trace_ui.js
+++ b/src/trace_ui.js
@@ -41,10 +41,10 @@ function createTableStartWithInfo(data) {
   return header;
 }
 
-function createTableStartWithLink(data, modelName, linkInfo, tracingMode) {
+function createTableStartWithLink(data, modelName, linkInfo, traceMode) {
   var header = createTableStart();
-  header += createTableRowWithLink(data, modelName, linkInfo, tracingMode) +
-      '</thead>';
+  header +=
+      createTableRowWithLink(data, modelName, linkInfo, traceMode) + '</thead>';
   return header;
 }
 
@@ -74,15 +74,15 @@ function getParaFromLinkInfo(linkInfo) {
 }
 
 // linkinfo:  {date: 2022, gpufreq: 192000}
-function createTableRowWithLink(data, modelName, linkInfo, tracingMode) {
+function createTableRowWithLink(data, modelName, linkInfo, traceMode) {
   let tr = '<tr>';
   const linkStr = getParaFromLinkInfo(linkInfo);
   const rawTimestamp = '&rawtimestamp=true';
   for (key in data) {
     if (data[key] != 'name') {
-      if (tracingMode == 'all') {
+      if (traceMode == 'all') {
         tr += `<td><a href="./../../timeline.html?${linkStr}&${
-            rawTimestamp}&trace=${modelName}-${key}">${data[key]}</a>
+            rawTimestamp}&tracefile=${modelName}-${key}">${data[key]}</a>
           </td>`;
       } else {
         tr += `<td><a href="./../../timeline.html?${linkStr}&${

--- a/src/trace_util.js
+++ b/src/trace_util.js
@@ -1,0 +1,138 @@
+function getJsonFromString(str, start, end) {
+  const regStr = String.raw`${start}.*?${end}`;
+  var matchRegex = new RegExp(regStr, 'g');
+  const matchResults = str.match(matchRegex);
+  if (Array.isArray(matchResults)) {
+    var results = [];
+    for (const item of matchResults) {
+      results.push(JSON.parse(item.replace(start, '').replace(end, '')));
+    }
+    return results;
+  } else {
+    if (matchResults == null) throw new Error('Please make sure log is valid!');
+    return new Array(
+        JSON.parse(matchResults.replace(start, '').replace(end, '')));
+  }
+}
+
+function getModelNames(modelNamesJson) {
+  if (modelNamesJson == null) {
+    console.error('No Model names!');
+    return [];
+  }
+  const modelNames = [];
+  for (const item in modelNamesJson['performance']) {
+    modelNames.push(modelNamesJson['performance'][item][0].replace(/ /g, '_'));
+  }
+  return modelNames;
+}
+
+// Make name simple.
+function getName(item) {
+  return item.replace(/[\[\]]/g, '').replace(/\//g, '_').replace(/[,\s]/g, '-');
+}
+
+function getModelNamesFromLog(logStr) {
+  const matchRegex = /\[\d{1,2}\/\d{1,2}\].*webgpu/g;
+  const matchResults = logStr.match(matchRegex);
+
+  if (Array.isArray(matchResults)) {
+    var results = [];
+    for (const item of matchResults) {
+      const name = getName(item);
+      results.push(name);
+    }
+    return results;
+  } else {
+    return getName(matchResults);
+  }
+}
+
+function getAverageInfoFromLog(logStr) {
+  // TODO: This regex takes too long.
+  const matchRegex = /.*\[object Object\]/g;
+  const matchResults = logStr.match(matchRegex);
+  return matchResults;
+}
+
+async function readFileAsync(fileName) {
+  const fsasync = require('fs').promises;
+  return await fsasync.readFile(fileName, 'binary');
+}
+
+
+function pushEvents(results, runCount, event, inModel) {
+  if (!inModel) {
+    return;
+  }
+  if (!(runCount in results)) {
+    results[runCount] = [];
+  }
+  // Event is us. Result is ms.
+  results[runCount].push(event);
+}
+
+async function splitTraceByModel(traceFile, modelSummarDir) {
+  const eventNames = [
+    'DeviceBase::APICreateComputePipeline',
+    'CreateComputePipelineAsyncTask::Run', 'DeviceBase::APICreateShaderModule',
+    'Queue::Submit'
+  ];
+
+  const eventJSTimestampNames = [
+    'predict', 'timeInferenceForTracing', 'JSSubmitQueue', 'JSGetBufferData',
+    'JSGetBufferDataEnd', 'JSGetKernelTimesEnd', 'JSrunWebGLProgram',
+    'JSrunWebGLProgramEnd', 'JSreadSync', 'JSreadSyncEnd', 'JSread', 'JSreadEnd'
+  ];
+
+  const dawnTimestampName =
+      'd3d12::CommandRecordingContext::ExecuteCommandList Detailed Timing';
+
+  let results = [];
+
+  let jsonData =
+      JSON.parse(await readFileAsync(`${modelSummarDir}/${traceFile}`));
+  const traceEndTag = 'metadata';
+  const traceEnd = jsonData[traceEndTag];
+  let runCount = -1;
+  let inModel = false;
+  for (let event of jsonData['traceEvents']) {
+    let eventName = event['name'];
+
+    let jsMessageName;
+    if (event['args'] && event['args']['data'] &&
+        event['args']['data']['message']) {
+      jsMessageName = event['args']['data']['message'];
+    }
+
+    const modelBeginMessage = 'predict';
+    const modelEndMessage = 'JSGetKernelTimesEnd';
+    const eventJSTimestampNameIndex =
+        eventJSTimestampNames.indexOf(jsMessageName);
+    if (eventJSTimestampNameIndex >= 0 && eventName == 'TimeStamp') {
+      if (jsMessageName == modelBeginMessage) {
+        runCount++;
+        inModel = true;
+        pushEvents(results, runCount, event, inModel);
+      } else if (jsMessageName == modelEndMessage) {
+        pushEvents(results, runCount, event, inModel);
+        inModel = false;
+      } else {
+        pushEvents(results, runCount, event, inModel);
+      }
+    } else if (eventName == dawnTimestampName) {
+      pushEvents(results, runCount, event, inModel);
+    } else if (eventNames.indexOf(eventName) >= 0) {
+      pushEvents(results, runCount, event, inModel);
+    }
+  }
+  return [results, traceEnd];
+}
+
+module.exports = {
+  getJsonFromString: getJsonFromString,
+  getModelNames: getModelNames,
+  getModelNamesFromLog: getModelNamesFromLog,
+  getAverageInfoFromLog: getAverageInfoFromLog,
+  splitTraceByModel: splitTraceByModel,
+};

--- a/src/trace_util.js
+++ b/src/trace_util.js
@@ -80,8 +80,8 @@ async function splitTraceByModel(traceFile, modelSummarDir) {
   ];
 
   const eventJSTimestampNames = [
-    'predict', 'timeInferenceForTracing', 'JSSubmitQueue', 'JSGetBufferData',
-    'JSGetBufferDataEnd', 'JSGetKernelTimesEnd', 'JSrunWebGLProgram',
+    'predict', 'timeInferenceForTracing', 'JSsubmitQueue', 'JSgetBufferData',
+    'JSgetBufferDataEnd', 'JSgetKernelTimesEnd', 'JSrunWebGLProgram',
     'JSrunWebGLProgramEnd', 'JSreadSync', 'JSreadSyncEnd', 'JSread', 'JSreadEnd'
   ];
 
@@ -106,7 +106,7 @@ async function splitTraceByModel(traceFile, modelSummarDir) {
     }
 
     const modelBeginMessage = 'predict';
-    const modelEndMessage = 'JSGetKernelTimesEnd';
+    const modelEndMessage = 'JSgetKernelTimesEnd';
     const eventJSTimestampNameIndex =
         eventJSTimestampNames.indexOf(jsMessageName);
     if (eventJSTimestampNameIndex >= 0 && eventName == 'TimeStamp') {

--- a/src/util.js
+++ b/src/util.js
@@ -58,6 +58,10 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function getTraceFlag() {
+ return 'trace' in this.args || 'trace-category' in this.args;
+}
+
 module.exports = {
   'browserArgs': '--enable-unsafe-webgpu --disable-dawn-features=disallow_unsafe_apis --enable-features=WebAssemblyThreads,SharedArrayBuffer,WebAssemblySimd,MediaFoundationD3D11VideoCapture --start-maximized',
   'hostname': os.hostname(),
@@ -70,9 +74,11 @@ module.exports = {
   'benchmarkUrlArgs': 'WEBGL_USE_SHAPES_UNIFORMS=true&CHECK_COMPUTATION_FOR_ERRORS=false',
   'demoUrl': 'https://wp-27.sh.intel.com/workspace/project/tfjswebgpu/tfjs-models/pose-detection/demos',
   'timeout': 180 * 1000,
+  'gpufreqTraceFile': '',
   capitalize: capitalize,
   getDuration: getDuration,
   log: log,
   sleep: sleep,
   uncapitalize: uncapitalize,
+  getTraceFlag: getTraceFlag,
 };


### PR DESCRIPTION
Steps for how to get trace data:

1) Before run any commands below, git clone https://github.com/tensorflow/tfjs/pull/6401 first, then setup it with npx-httpserver.

2) Use webtest to get CPU-GPU timeline data(To get warmup trace, add: --warmup-times 0 --run-times 1).
node src/main.js --target performance --performance-backend webgpu --benchmark-url https://127.0.0.1:8080/tfjs/e2e/benchmarks/local-benchmark/ --trace --benchmark bodypix

To view data, copy data from webtest\out to timeline. Then setup a web server under timeline.